### PR TITLE
Capitalization bug fixes

### DIFF
--- a/scripts/ga_uploadBatch.py
+++ b/scripts/ga_uploadBatch.py
@@ -32,7 +32,7 @@ print(config)
 #prepare the data to send
 data = {
 			'ApiUserKey': config['apiUserKey'],
-			'ApiUserID': config['apiUserId']
+			'ApiUserId': config['apiUserId']
 	    }
 
 files = { 'batchFile': open(batchFile, "rb") }

--- a/scripts/ga_uploadSample_json.py
+++ b/scripts/ga_uploadSample_json.py
@@ -100,7 +100,7 @@ data['SnvFile'] = snvBaseName
 data['StructFile'] = svBaseName
 # add user connection fields
 data['ApiUserKey'] = config['apiUserKey']
-data['ApiUserID'] = config['apiUserId']
+data['ApiUserId'] = config['apiUserId']
 print(data)
 
 


### PR DESCRIPTION
We found an issue in the GeneYX API scripts on GitHub that's causing upload failures:

Files affected:
- scripts/ga_uploadSample_json.py (line 103)
- scripts/ga_uploadBatch.py (line ~30)

Bug:
data['ApiUserID'] = config['apiUserId']

Should be:
data['ApiUserId'] = config['apiUserId']

The API expects 'ApiUserId' (with lowercase 'Id'), but the scripts are sending 'ApiUserID' (with uppercase 'ID'), which causes "Invalid ApiUserID" errors.

This prevents sample uploads from working with the official scripts. We had to create a local patched copy to work around it.
